### PR TITLE
CircleCIのエラー時の文字化けを直す

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,10 @@
 version: 2.1
 
-orbs:
-  win: circleci/windows@2.2.0
 
 jobs:
   build:
-    executor: win/default     
+    docker:
+      - image: mcr.microsoft.com/dotnet/core/sdk:3.1
     
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,13 @@
- version: 2.1
+version: 2.1
 
- orbs:
+orbs:
   win: circleci/windows@2.2.0
 
- jobs:
-   build:
-     executor: win/default     
+jobs:
+  build:
+    executor: win/default     
     
-     steps:
-       - checkout
-       - run: dotnet build
-       - run: dotnet test -c Debug
+    steps:
+      - checkout
+      - run: dotnet build
+      - run: dotnet test -c Debug

--- a/Test/予約期間Test.cs
+++ b/Test/予約期間Test.cs
@@ -23,7 +23,7 @@ namespace Test
             {
                 var me = new 予約期間(new 予約年月日(2020, 2, 23), 予約開始_時._13, 予約開始_分._00, new コマ数(8));
                 var 被っている = me.時間かぶってますか(_target);
-                Assert.True(被っている);
+                Assert.True(false);
             }
 
             /// <summary>

--- a/Test/予約期間Test.cs
+++ b/Test/予約期間Test.cs
@@ -23,7 +23,7 @@ namespace Test
             {
                 var me = new 予約期間(new 予約年月日(2020, 2, 23), 予約開始_時._13, 予約開始_分._00, new コマ数(8));
                 var 被っている = me.時間かぶってますか(_target);
-                Assert.True(false);
+                Assert.True(被っている);
             }
 
             /// <summary>


### PR DESCRIPTION
なんとかして「設定」や「小手先」で直そうと思ったが、出来なかったので「CircleCI自体が用意するWindowsのコンテナ」を利用しているの着目し、ローカルでテストが通る(かつ文字化けせずにファイル名が表示できる)Microsoftが用意している.Net Coreの公式イメージでテストするように変える。

(公式なので、意味的にはこちらのコンテナのほうが”順当”で、信憑性が高いとも考えられる)

## 変更点

- CircleCIの実行コンテナを `circleci/windows` から `mcr.microsoft.com/dotnet/core/sdk:3.1` に変更
- yamlのインデントが「なんだか不思議な感じ」になってたので、フォーマット

## 想定される影響

- 少しCIが遅くなる可能性がある(感覚では45s->1mくらい)
